### PR TITLE
update bridge-to-transparent.yaml

### DIFF
--- a/03-TigeraSecure-Install/bridge-to-transparent.yaml
+++ b/03-TigeraSecure-Install/bridge-to-transparent.yaml
@@ -8,7 +8,7 @@ rules:
 # Allow kubectl to drain/uncordon
 #
 # NB: These permissions are tightly coupled to the bundled version of kubectl; the ones below
-# match https://github.com/kubernetes/kubernetes/blob/v1.12.1/pkg/kubectl/cmd/drain.go
+# match https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/drain/drain.go
 #
 - apiGroups: [""]
   resources: ["nodes"]
@@ -16,9 +16,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs:     ["list","delete","get"]
-- apiGroups: ["extensions"]
+- apiGroups: ["extensions","apps"]
   resources: ["daemonsets"]
-  verbs:     ["get"]
+  verbs:     ["get","update"]
 - apiGroups: [""]
   resources: ["pods/eviction"]
   verbs:     ["create"]


### PR DESCRIPTION
DaemonSets resource was moved into `apps` apiGroup. The newer k8s versions (v1.16+) also require `update` verb to be allowed for the `daemonsets` resource in the `ClusterRole`.